### PR TITLE
fix: quote folder-uri in WSL cmd /c to prevent double-window bug

### DIFF
--- a/src/main/kotlin/com/github/wanniwa/editorjumper/editors/EditorHandler.kt
+++ b/src/main/kotlin/com/github/wanniwa/editorjumper/editors/EditorHandler.kt
@@ -146,7 +146,7 @@ abstract class BaseEditorHandler(private val customPath: String?) : EditorHandle
         val quote = shouldQuotePaths()
         val useCmd = SystemInfo.isWindows && editorPath == getDefaultPath()
 
-        val quotedFolderUri = if (quote) "\"$folderUri\"" else folderUri
+        val quotedFolderUri = if (useCmd || quote) "\"$folderUri\"" else folderUri
 
         val base = if (useCmd) {
             arrayOf("cmd", "/c", editorPath)
@@ -165,7 +165,6 @@ abstract class BaseEditorHandler(private val customPath: String?) : EditorHandle
             val gotoArg = "$linuxFilePath:$actualLineNumber:$actualColumnNumber"
             val finalGotoArg = if (quote) "\"$gotoArg\"" else gotoArg
             base + arrayOf("--folder-uri", quotedFolderUri, "--goto", finalGotoArg)
-            base + arrayOf("--folder-uri", quotedFolderUri, "--goto", gotoArg)
         } else {
             base + arrayOf("--folder-uri", quotedFolderUri)
         }


### PR DESCRIPTION
## Summary

- 修复 Windows IDEA 打开 WSL 项目时，右键在 Cursor/VSCode 中打开文件会出现两个窗口的 bug
- `buildWslCommand` 通过 `cmd /c` 执行时，`--folder-uri` 的值 `vscode-remote://wsl+Distro/path` 含有 `://`、`+` 等特殊字符，未加引号导致 cmd.exe 错误解析参数
- 同时修复了一个死代码 bug：`finalGotoArg`（引号处理后的 goto 参数）被废弃表达式丢弃，实际返回的是未处理的 `gotoArg`

## Changes

- `buildWslCommand` 中 `quotedFolderUri` 在 `useCmd`（即 `cmd /c`）场景下始终加引号
- 删除冗余的死代码行，使 `finalGotoArg` 正确生效

## Test plan

- [x] 现有单元测试通过（`./gradlew test`）
- [ ] 在 Windows IDEA 中打开 WSL 项目，右键文件选择在 Cursor 中打开，验证只打开一个窗口且正确定位到文件

Made with [Cursor](https://cursor.com)