### PR TITLE
feat: 重新实现 WSL 远程开发支持（两步命令策略）

### DIFF
--- a/src/main/kotlin/com/github/wanniwa/editorjumper/actions/BaseAction.kt
+++ b/src/main/kotlin/com/github/wanniwa/editorjumper/actions/BaseAction.kt
@@ -116,7 +116,38 @@ abstract class BaseAction : AnAction() {
         val projectPath = getProjectPath(project) ?: return
         val filePath = getFilePath(file)
 
-        // 使用 getOpenCommand 方法
+        // WSL 两步命令：先打开项目窗口，再定位文件
+        val wslCommands = handler.buildWslCommands(projectPath, filePath, lineNumber, columnNumber)
+        if (wslCommands != null) {
+            val (openCmd, gotoCmd) = wslCommands
+            try {
+                logger.info("EditorJumper WSL step1: ${openCmd.joinToString(" ")}")
+                ProcessBuilder(openCmd.toList())
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start()
+                    .outputStream.close()
+
+                if (gotoCmd != null) {
+                    Thread.sleep(2000)
+                    logger.info("EditorJumper WSL step2: ${gotoCmd.joinToString(" ")}")
+                    ProcessBuilder(gotoCmd.toList())
+                        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                        .redirectError(ProcessBuilder.Redirect.DISCARD)
+                        .start()
+                        .outputStream.close()
+                }
+            } catch (e: Exception) {
+                Messages.showErrorDialog(
+                    project,
+                    "Failed to open editor in WSL mode. Error: ${e.message}",
+                    "Editor Launch Failed"
+                )
+            }
+            return
+        }
+
+        // 非 WSL：使用 getOpenCommand 方法
         val command = handler.getOpenCommand(
             projectPath,
             filePath,
@@ -129,10 +160,10 @@ abstract class BaseAction : AnAction() {
 
         try {
             ProcessBuilder(command.toList())
-                .redirectOutput(ProcessBuilder.Redirect.DISCARD) // 丢弃 stdout
-                .redirectError(ProcessBuilder.Redirect.DISCARD)  // 丢弃 stderr
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start()
-                .outputStream.close() // 明确告诉子进程我不会输入任何数据
+                .outputStream.close()
         } catch (e: Exception) {
             Messages.showErrorDialog(
                 project,

--- a/src/main/kotlin/com/github/wanniwa/editorjumper/actions/BaseAction.kt
+++ b/src/main/kotlin/com/github/wanniwa/editorjumper/actions/BaseAction.kt
@@ -9,6 +9,7 @@ import com.github.wanniwa.editorjumper.utils.I18nUtils
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
@@ -116,33 +117,37 @@ abstract class BaseAction : AnAction() {
         val projectPath = getProjectPath(project) ?: return
         val filePath = getFilePath(file)
 
-        // WSL 两步命令：先打开项目窗口，再定位文件
+        // WSL 两步命令：先打开项目窗口，再定位文件（在后台线程执行，避免 sleep 阻塞 EDT）
         val wslCommands = handler.buildWslCommands(projectPath, filePath, lineNumber, columnNumber)
         if (wslCommands != null) {
             val (openCmd, gotoCmd) = wslCommands
-            try {
-                logger.info("EditorJumper WSL step1: ${openCmd.joinToString(" ")}")
-                ProcessBuilder(openCmd.toList())
-                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-                    .redirectError(ProcessBuilder.Redirect.DISCARD)
-                    .start()
-                    .outputStream.close()
-
-                if (gotoCmd != null) {
-                    Thread.sleep(2000)
-                    logger.info("EditorJumper WSL step2: ${gotoCmd.joinToString(" ")}")
-                    ProcessBuilder(gotoCmd.toList())
+            ApplicationManager.getApplication().executeOnPooledThread {
+                try {
+                    logger.info("EditorJumper WSL step1: ${openCmd.joinToString(" ")}")
+                    ProcessBuilder(openCmd.toList())
                         .redirectOutput(ProcessBuilder.Redirect.DISCARD)
                         .redirectError(ProcessBuilder.Redirect.DISCARD)
                         .start()
                         .outputStream.close()
+
+                    if (gotoCmd != null) {
+                        Thread.sleep(2000)
+                        logger.info("EditorJumper WSL step2: ${gotoCmd.joinToString(" ")}")
+                        ProcessBuilder(gotoCmd.toList())
+                            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                            .redirectError(ProcessBuilder.Redirect.DISCARD)
+                            .start()
+                            .outputStream.close()
+                    }
+                } catch (e: Exception) {
+                    ApplicationManager.getApplication().invokeLater {
+                        Messages.showErrorDialog(
+                            project,
+                            "Failed to open editor in WSL mode. Error: ${e.message}",
+                            "Editor Launch Failed"
+                        )
+                    }
                 }
-            } catch (e: Exception) {
-                Messages.showErrorDialog(
-                    project,
-                    "Failed to open editor in WSL mode. Error: ${e.message}",
-                    "Editor Launch Failed"
-                )
             }
             return
         }

--- a/src/main/kotlin/com/github/wanniwa/editorjumper/editors/EditorHandler.kt
+++ b/src/main/kotlin/com/github/wanniwa/editorjumper/editors/EditorHandler.kt
@@ -1,6 +1,7 @@
 package com.github.wanniwa.editorjumper.editors
 
 import com.github.wanniwa.editorjumper.settings.EditorJumperProjectSettings
+import com.github.wanniwa.editorjumper.utils.WslUtils
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import java.io.File
@@ -19,6 +20,8 @@ data class EditorConfig(
     val supportsWorkspace: Boolean = false,
     /** If true, project/file paths are quoted to avoid spaces being split (e.g. Cursor). */
     val quotePaths: Boolean = false,
+    /** If true, the editor supports --folder-uri / --remote for WSL remote development. */
+    val supportsWsl: Boolean = false,
 )
 
 /**
@@ -72,6 +75,27 @@ interface EditorHandler {
      * 默认为 false，由具体实现（现在是配置）决定。
      */
     fun shouldQuotePaths(): Boolean = false
+
+    /**
+     * 是否支持 WSL 远程开发。
+     * 默认为 false，由具体实现（现在是配置）决定。
+     */
+    fun supportsWsl(): Boolean = false
+
+    /**
+     * 构建 WSL 两步命令。
+     * 参考 MingSpace 的方案，分两步绕过 Electron 对 :// 参数的过滤：
+     * 第一步用 --folder-uri 打开 WSL 项目窗口，第二步用 --reuse-window --remote --goto 定位文件。
+     *
+     * @return Pair(打开项目命令, 定位文件命令)，定位文件命令在无文件时为 null；
+     *         如果不是 WSL 场景则返回 null。
+     */
+    fun buildWslCommands(
+        projectPath: String,
+        filePath: String?,
+        lineNumber: Int?,
+        columnNumber: Int?
+    ): Pair<Array<String>, Array<String>?>? = null
 }
 
 abstract class BaseEditorHandler(private val customPath: String?) : EditorHandler {
@@ -113,6 +137,38 @@ abstract class BaseEditorHandler(private val customPath: String?) : EditorHandle
                 }
             }
         }
+    }
+
+    override fun buildWslCommands(
+        projectPath: String,
+        filePath: String?,
+        lineNumber: Int?,
+        columnNumber: Int?
+    ): Pair<Array<String>, Array<String>?>? {
+        if (!SystemInfo.isWindows || !supportsWsl() || !WslUtils.isWslPath(projectPath)) return null
+        val distro = WslUtils.extractDistro(projectPath) ?: return null
+
+        val linuxProjectPath = WslUtils.toLinuxPath(projectPath)
+        val folderUri = "vscode-remote://wsl+$distro$linuxProjectPath"
+        val editorPath = getPath()
+        val useCmd = editorPath == getDefaultPath()
+
+        val base = if (useCmd) arrayOf("cmd", "/c", editorPath) else arrayOf(editorPath)
+
+        // 第一步：用 --folder-uri 打开 WSL 项目窗口
+        val openCmd = base + arrayOf("--folder-uri", folderUri)
+
+        // 第二步：用 --reuse-window --remote --goto 定位文件（仅有文件时）
+        val gotoCmd = if (filePath != null) {
+            val linuxFilePath = if (WslUtils.isWslPath(filePath)) WslUtils.toLinuxPath(filePath) else filePath
+            val actualLine = lineNumber ?: 1
+            val actualColumn = columnNumber ?: 1
+            base + arrayOf("--reuse-window", "--remote", "wsl+$distro", "--goto", "$linuxFilePath:$actualLine:$actualColumn")
+        } else {
+            null
+        }
+
+        return Pair(openCmd, gotoCmd)
     }
 
     override fun getFastOpenCommand(
@@ -187,4 +243,6 @@ class ConfigBasedEditorHandler(
     }
 
     override fun shouldQuotePaths(): Boolean = cfg.quotePaths
+
+    override fun supportsWsl(): Boolean = cfg.supportsWsl
 }

--- a/src/main/kotlin/com/github/wanniwa/editorjumper/utils/WslUtils.kt
+++ b/src/main/kotlin/com/github/wanniwa/editorjumper/utils/WslUtils.kt
@@ -1,0 +1,59 @@
+package com.github.wanniwa.editorjumper.utils
+
+/**
+ * WSL (Windows Subsystem for Linux) 路径检测与转换工具。
+ *
+ * WSL 项目通过 UNC 路径访问，格式如：
+ * - `\\wsl$\Ubuntu\home\user\project`
+ * - `\\wsl.localhost\Ubuntu\home\user\project`
+ */
+object WslUtils {
+
+    private const val WSL_DOLLAR_PREFIX = "\\\\wsl\$\\"
+    private const val WSL_LOCALHOST_PREFIX = "\\\\wsl.localhost\\"
+
+    private val WSL_PREFIXES = listOf(WSL_DOLLAR_PREFIX, WSL_LOCALHOST_PREFIX)
+
+    /**
+     * 判断 [path] 是否为指向 WSL 发行版的 Windows UNC 路径。
+     */
+    fun isWslPath(path: String): Boolean {
+        if (path.length < 5) return false
+        val normalized = path.replace('/', '\\')
+        return WSL_PREFIXES.any { normalized.startsWith(it, ignoreCase = true) }
+    }
+
+    /**
+     * 从 WSL UNC 路径中提取发行版名称。
+     *
+     * `\\wsl$\Ubuntu\home\user` → `Ubuntu`
+     *
+     * @return 发行版名称，如果 [wslPath] 不是有效的 WSL UNC 路径则返回 null。
+     */
+    fun extractDistro(wslPath: String): String? {
+        val normalized = wslPath.replace('/', '\\')
+        val prefix = WSL_PREFIXES.firstOrNull { normalized.startsWith(it, ignoreCase = true) }
+            ?: return null
+        val afterPrefix = normalized.substring(prefix.length)
+        if (afterPrefix.isEmpty()) return null
+        val nextSlash = afterPrefix.indexOf('\\')
+        val distro = if (nextSlash >= 0) afterPrefix.substring(0, nextSlash) else afterPrefix
+        return distro.ifEmpty { null }
+    }
+
+    /**
+     * 将 Windows WSL UNC 路径转换为对应的 Linux 路径。
+     * 如果 [wslPath] 不是 WSL UNC 路径，原样返回。
+     *
+     * `\\wsl$\Ubuntu\home\user\project` → `/home/user/project`
+     */
+    fun toLinuxPath(wslPath: String): String {
+        if (!isWslPath(wslPath)) return wslPath
+        val normalized = wslPath.replace('/', '\\')
+        val prefix = WSL_PREFIXES.first { normalized.startsWith(it, ignoreCase = true) }
+        val afterPrefix = normalized.substring(prefix.length)
+        val firstSlash = afterPrefix.indexOf('\\')
+        val linuxPart = if (firstSlash >= 0) afterPrefix.substring(firstSlash) else "/"
+        return linuxPart.replace('\\', '/')
+    }
+}

--- a/src/main/resources/editors.json
+++ b/src/main/resources/editors.json
@@ -5,7 +5,8 @@
     "winPath": "Code",
     "linuxPath": "Code",
     "macOpenName": "vscode",
-    "supportsWorkspace": true
+    "supportsWorkspace": true,
+    "supportsWsl": true
   },
   {
     "name": "Cursor",
@@ -13,7 +14,8 @@
     "winPath": "Cursor",
     "linuxPath": "Cursor",
     "macOpenName": "cursor",
-    "supportsWorkspace": true
+    "supportsWorkspace": true,
+    "supportsWsl": true
   },
   {
     "name": "Trae",
@@ -21,7 +23,8 @@
     "winPath": "Trae",
     "linuxPath": "Trae",
     "macOpenName": "trae",
-    "supportsWorkspace": true
+    "supportsWorkspace": true,
+    "supportsWsl": true
   },
   {
     "name": "Trae CN",
@@ -29,7 +32,8 @@
     "winPath": "Trae",
     "linuxPath": "Trae",
     "macOpenName": "trae-cn",
-    "supportsWorkspace": true
+    "supportsWorkspace": true,
+    "supportsWsl": true
   },
   {
     "name": "Windsurf",


### PR DESCRIPTION
## Credits

感谢 [@MingSpace](https://github.com/MingSpace) 提供 WSL 两步命令的思路及脚本实现，本 PR 在其方案基础上以插件形式集成。再次感谢大佬！

## Summary

Closes #10

重新实现 WSL 远程开发支持，替代已 revert 的 #44。

核心改进：采用**两步命令策略**，绕过 Electron 对 `://` 参数的过滤问题——
第一步通过 `--folder-uri` 打开 WSL 项目窗口，第二步通过 `--reuse-window --remote --goto` 定位到具体文件和行列。

## Changes

- **新增 `WslUtils` 工具类** — 提供 WSL UNC 路径检测（`\\wsl$\`、`\\wsl.localhost\`）、发行版名称提取、Windows→Linux 路径转换
- **`EditorHandler` 新增 `buildWslCommands()` 方法** — 实现两步命令构建逻辑，仅在 Windows + WSL 路径场景下生效
- **`BaseAction` 集成 WSL 命令分支** — 优先尝试 WSL 两步命令，非 WSL 场景走原有逻辑，零侵入
- **`editors.json` 配置** — 为 VS Code、Cursor、Trae、Trae CN 启用 `supportsWsl: true`

## 前置要求

- 编辑器需安装 **WSL 扩展**（如 VS Code 的 `ms-vscode-remote.remote-wsl`），否则会提示：
  > 打开远程窗口需要扩展"WSL"。确定要安装扩展吗？

## Test Plan

已在以下环境完成手工测试（WSL2 发行版：Debian 13）：

**WSL 远程项目**（通过 JetBrains Remote Development 打开 WSL 内项目）

| IDE | 版本 | 目标编辑器 | 右键项目打开 | 右键文件打开并定位 |
|-----|------|-----------|:---:|:---:|
| IntelliJ IDEA | 2026.1.1 | Cursor 3.0.16 | ✅ | ✅ |
| IntelliJ IDEA | 2026.1.1 | VS Code 1.105.1 | ✅ | ✅ |
| WebStorm | 2026.1 | Cursor 3.0.16 | ✅ | ✅ |
| WebStorm | 2026.1 | VS Code 1.105.1 | ✅ | ✅ |

**Windows 本地项目**（验证对现有功能无回归）

| IDE | 版本 | 目标编辑器 | 右键项目打开 | 右键文件打开并定位 |
|-----|------|-----------|:---:|:---:|
| IntelliJ IDEA | 2026.1.1 | Cursor 3.0.16 | ✅ | ✅ |
| IntelliJ IDEA | 2026.1.1 | VS Code 1.105.1 | ✅ | ✅ |
| WebStorm | 2026.1 | Cursor 3.0.16 | ✅ | ✅ |
| WebStorm | 2026.1 | VS Code 1.105.1 | ✅ | ✅ |

Made with [Cursor](https://cursor.com)