### PR TITLE
fix: 修复状态栏组件在 EDT 上触发阻塞式 Service 初始化的问题

### DIFF
--- a/src/main/kotlin/com/github/wanniwa/editorjumper/statusbar/EditorJumperStatusBarWidget.kt
+++ b/src/main/kotlin/com/github/wanniwa/editorjumper/statusbar/EditorJumperStatusBarWidget.kt
@@ -44,8 +44,8 @@ class EditorJumperStatusBarWidget(private val project: Project) : StatusBarWidge
     override fun getTooltipText(): String = I18nUtils.message("statusbar.tooltip")
 
     override fun getSelectedValue(): String {
-        val projectSettings = EditorJumperProjectSettings.getInstance(project)
-        val editorType = if (projectSettings.projectEditorType.isBlank()) {
+        val projectSettings = project.getServiceIfCreated(EditorJumperProjectSettings::class.java)
+        val editorType = if (projectSettings == null || projectSettings.projectEditorType.isBlank()) {
             EditorJumperSettings.getInstance().selectedEditorType
         } else {
             projectSettings.projectEditorType


### PR DESCRIPTION
关联 #48

## 问题

在 IntelliJ IDEA 2026.1.1 中，`EditorJumperStatusBarWidget.getSelectedValue()` 在启动时抛出 `IllegalStateException`。该方法调用 `EditorJumperProjectSettings.getInstance(project)`，首次访问时会在 EDT 上触发项目级 `PersistentStateComponent` 的初始化，初始化链最终调用了 `runBlockingCancellable`——该方法在较新版本的 IntelliJ Platform 中[已被禁止在 EDT 上执行](https://plugins.jetbrains.com/docs/intellij/general-threading-rules.html)。

WebStorm 2026.1 未触发此问题，推测原因是 WebStorm 不包含 Maven 插件（宏展开调用链中的关键环节）。

## 修复方案

在 `getSelectedValue()` 中，将 `EditorJumperProjectSettings.getInstance(project)` 替换为 `project.getServiceIfCreated(EditorJumperProjectSettings::class.java)`。

| 方法 | Service 未初始化时的行为 |
|---|---|
| `getService()` / `getInstance()` | **强制同步初始化** — 在 EDT 上触发阻塞调用链 |
| `getServiceIfCreated()` | **返回 null** — 不触发初始化，不阻塞 |

当 Service 尚未初始化时（如 IDE 启动早期），组件回退到全局编辑器设置。平台在后台线程完成 Service 初始化后，后续调用即可正常获取项目级设置。

## 兼容性

- `ComponentManager.getServiceIfCreated()` 自 IntelliJ Platform **2019.2**（build 192）起可用
- 插件 `sinceBuild` 为 `231` — **完全向后兼容**，无需调整版本要求

## 测试

- **IntelliJ IDEA 2026.1.1**（已配置项目级编辑器设置）：异常不再出现
- **WebStorm 2026.1**：功能正常，无影响